### PR TITLE
detect cold start by checking if year is 80

### DIFF
--- a/L76GNSV4.py
+++ b/L76GNSV4.py
@@ -270,7 +270,24 @@ class L76GNSS:
         if msg is not None:
             utc_time = msg['UTCTime']
             utc_date = msg['Date']
+            if str(utc_date)[-2:] == '80':
+                return None
             return "20{}-{}-{}T{}:{}:{}+00:00".format(utc_date[4:6], utc_date[2:4], utc_date[0:2],
                                                       utc_time[0:2], utc_time[2:4], utc_time[4:6])
+        else:
+            return None
+
+    def getUTCDateTimeTuple(self, debug=False):
+        """return UTC date time or None when nothing if found"""
+        msg = self._read_message(messagetype='RMC', debug=debug)
+        if msg is not None:
+            utc_time = msg['UTCTime']
+            utc_date = msg['Date']
+            print('utc_date type: %s' % type(utc_date)
+            if str(utc_date)[-2:] == '80':
+                return None
+            year = '20'
+            year += utc_date[4:6]
+            return (int(year), int(utc_date[2:4]), int(utc_date[0:2]), int(utc_time[0:2]), int(utc_time[2:4]), int(utc_time[4:6]))
         else:
             return None


### PR DESCRIPTION
GPS epoch is January 6 1980. On cold boot, L76 returns "80" in the timestamp year field.

So, I modified the getUTCDateTime() method to return None if year is 80 to avoid false reading on cold start.

getUTCTime should probably be changed too, to grab the full date-time value from RMC so we can check if the year is 1980. Otherwise, there's no way to know if the getUTCTime is accurate or not from the result, alone.

I also added a new getUTCDateTimeTuple() method to return tuple of ints with full year that can be passed directly to the RTC for GPS time sync. It's hard-coded right now to "20"+utc_date year bits. In year 2100 this will need to be changed.


Note, this code does not account for leap seconds, or offset of GPS time from UT. As far as I can tell, the L76 receiver doesn't output any kind of offset information, the [protocol specs](https://www.quectel.com/UploadImage/Downlad/Quectel_L76_Series_GNSS_Protocol_Specification_V3.3.pdf) to state the time is "UTC Time" and not "GPS Time" so perhaps it's corrected already.



Also, maybe it's better to look at the number of satellites in view to determine whether the fix is accurate, or not... Because otherwise, pulling a datetime from the GPS will definitely yield invalid results during a warm up, but you can fetch a datetime faster than doing a location fix, so it's not worth waiting for a fix just to sync the time.