### PR TITLE
Perf improvements

### DIFF
--- a/L76GNSV4.py
+++ b/L76GNSV4.py
@@ -63,11 +63,9 @@ class L76GNSS:
     def _read(self):
         """read the data stream form the gps"""
         # Changed from 64 to 128 - I2C L76 says it can read till 255 bytes
-        reg = b''
-        try:
+        reg = b""
+        while len(set(reg)) < 10: # Throw away empty buffers
             reg = self.i2c.readfrom(GPS_I2CADDR, 255)
-        except:
-            pass
         return reg
 
     @staticmethod
@@ -213,13 +211,6 @@ class L76GNSS:
 
     def _read_message(self, messagetype='GLL', timeout=None, debug=False):
         """read and decode a nmea sentence according to a messagetype"""
-        # if type(messagetype) == type(()):
-        #     mt = []
-        #     for m in messagetype:
-        #         mt += [m[-3:]]
-        #     messagetype = mt
-        # else:
-        #     messagetype = messagetype[-3:]
         if debug:
             print("messagetype", messagetype)
         messagefound = False
@@ -229,63 +220,37 @@ class L76GNSS:
         self.chrono.start()
         chrono_running = True
         while not messagefound and chrono_running:
-            nmea = self._read_message_raw() #  (debug=debug)
-            nmea_message = self._decodeNMEA(nmea, debug=debug)
             if debug:
-                print("nmea_message", nmea_message)
-            if nmea_message is not None:
-                messagefound = False
-                try:
-                    messagefound = (nmea_message['NMEA'][2:] in messagetype)
+                print("--Checking Mesages--")
+                print("Wanted messagetype", messagetype)
+            nmea_buffer = self._read().decode('utf-8')
+            # Is messagetype present in the data
+            if nmea_buffer.find(messagetype):
+                # break apart the long string into segments
+                # NMEA messages end with \r\n
+                for segment in nmea_buffer.split("\r\n"):
                     if debug:
-                        print(nmea_message['NMEA'], " -> ", nmea_message['NMEA'][2:], " => ", messagetype)
-                except:
-                    pass
-                try:
-                    messagefound = (nmea_message['PMTK'] in messagetype)
-                except:
-                    pass
-                try:
-                    messagefound = (nmea_message['PQVERNO'] in messagetype)
-                except:
-                    pass
-                # if index_message == messagetype:
-                #     messagefound = True
-                if debug:
-                    print("found message?", messagefound)
+                        print("segment", segment)
+                    # Does this segment contain the message we're looking for?
+                    if segment.find(messagetype) > 0:
+                        # Validate the whole message is present in segment
+                        if segment.startswith("$") and segment[len(segment)-3:len(segment)-2] == "*":
+                            # We now have what we want
+                            # Decode segment
+                            nmea_message = self._decodeNMEA(segment)
+                            if debug:
+                                print("Decoded nmea_message", nmea_message)
+                            self.lastmessage = nmea_message
+                            messagefound = True
+            if debug:
+                print("found message?", messagefound)
             if self.chrono.read() > timeout or messagefound:
                 self.chrono.stop()
                 chrono_running = False
-        self.lastmessage = nmea_message
         if messagefound:
             return nmea_message
         else:
             return None
-
-    def _read_message_raw(self, debug=False):
-        """reads output from the GPS and translates it to a message"""
-        nmea = b''
-        start = nmea.find(b'$')
-        while start < 0:
-            nmea += self._read() #.strip(b'\r\n')
-            start = nmea.find(b'$')
-        if debug:
-            print("nmea raw", len(nmea), start, nmea)
-        nmea = nmea[start:]
-        # end = nmea.find(b'*')
-        end = nmea.find(b'\r\n')
-        while end < 0:
-            nmea += self._read() #.strip(b'\r\n')
-            # end = nmea.find(b'*')
-            end = nmea.find(b'\r\n')
-        nmea = nmea[:end+3].decode('utf-8')
-        nmea = nmea[:-3]
-        nmea = nmea.replace('\n','')
-        if debug:
-            if nmea is not None:
-                print("nmea raw fix", self.fix, len(nmea), nmea)
-        gc.collect()
-        return nmea
 
     def fixed(self):
         """fixed yet? returns true or false"""


### PR DESCRIPTION
* _read now throws away any buffers too small to be messages. This eliminates processing of many empty and incomplete buffers. Also removed the Try loop since it was not being checked against anything. Much faster now.
* _read_message now more efficiently handles output from _read. It is designed to fail early instead of processing every buffer. It also processes all sentences in the buffer which was missing; only the first sentence was being processed.
    1. It checks to see if the messagetype exists in the buffer
    2. It then splits the buffer into segments and find the one containing the messagetype
    3. Then it validates the full message is present from $ to *##. 
    4. If that all checks out we decode the message.
* _read_message_raw No longer needed and was removed

NOTE: This does not make first fix faster from fullcoldstart. But I can now more often get 1 second L76 initialization times. Not always of course. And after initial fix, can get faster gps_message responses as well.

* `get_fix` didn't work because `_read_message` could not handle a tuple of messagetypes. Changed `_read_message` so it always uses tuples
* when the correct segment is found and we're checking messagetypes there were ocassionally extra loops. Added breaks to prevent this when messagefound is True
* Reordered the message types in `get_fix` so more common types are first in the tuple to search. With this and the breaks I now can get sub .2s fixes on a hot L76.